### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=id">Bahasa Indonesia</a>
+      </div>
+    </div>
+  </details>
+</div>
+
 # DivergenceMeter
 Analyzing real-world news, tries to estimate the current divergence value of the world in Steins;Gate terms.
 <div id="divergence-meter" style="cursor: pointer;">


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search.

Demo links : 
- [English](https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=en)
- [简体中文](https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=FrancescoCaracciolo&project=DivergenceMeter&lang=ko)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962" />

If this was not your expection, please close this PR. Thank you! 🙌

> OpenAiTx is an open soucre & free & no Ads project https://github.com/OpenAiTx/OpenAiTx
> List of github projects currently using OpenAiTx: https://openaitx.github.io/ 
